### PR TITLE
Allow defining Anypass environments with an env variable

### DIFF
--- a/src/AnyPassServiceProvider.php
+++ b/src/AnyPassServiceProvider.php
@@ -58,6 +58,15 @@ class AnyPassServiceProvider extends ServiceProvider
      */
     private function appEnvIsSafe()
     {
-        return in_array(env('APP_ENV'), ['local', 'testing']);
+        $csv = env('ANY_PASS_ENVIRONMENTS', 'local,testing');
+
+        $allowedEnvironments = collect(explode(',', $csv))
+            ->map(function ($string) {
+                return trim($string);
+            })
+            ->filter()
+            ->toArray();
+
+        return in_array(env('APP_ENV'), $allowedEnvironments);
     }
 }


### PR DESCRIPTION
This PR adds the ability to define the environments that Anypass works in. This is useful when you want to use Anypass on environments other than `local` or `testing` (such as `staging` or `acceptance`).

Since you can't define arrays in env values, the `ANY_PASS_ENVIRONMENTS` setting accepts a comma separated list of environments. If you don't explicitly define this env value, the default `local` and `testing` environments are used.

